### PR TITLE
The opls-AA dihedrals angle 2, 3, and 4 scalers before the angles whe…

### DIFF
--- a/Introduction to Molecular Dynamics.ipynb
+++ b/Introduction to Molecular Dynamics.ipynb
@@ -140,9 +140,9 @@
     "\n",
     "$U_{angle} = k_\\theta (\\theta-\\theta_0)^2$\n",
     "\n",
-    "$U_{dihedral} = \\frac {V_1} {2} \\left [ 1 + \\cos (\\phi-\\phi_0) \\right ]   + \\frac {V_2} {2} \\left [ 1 - \\cos 2(\\phi-\\phi_0) \\right ]\n",
-    "                + \\frac {V_3} {2} \\left [ 1 + \\cos 3(\\phi-\\phi_0) \\right ]\n",
-    "                + \\frac {V_4} {2} \\left [ 1 - \\cos 4(\\phi-\\phi_0) \\right ] $\n",
+    "$U_{dihedral} = \\frac {V_1} {2} \\left [ 1 + \\cos (\\phi-\\phi_0) \\right ]   + \\frac {V_2} {2} \\left [ 1 - \\cos (2\\phi-\\phi_0) \\right ]\n",
+    "                + \\frac {V_3} {2} \\left [ 1 + \\cos (3\\phi-\\phi_0) \\right ]\n",
+    "                + \\frac {V_4} {2} \\left [ 1 - \\cos (4\\phi-\\phi_0) \\right ] $\n",
     "                \n",
     "Here, $r$ represents the separation between two atoms, $\\theta$ the angle between 3 atoms, $\\phi$ is between 4 atoms, $q_i$ is the charge on atom \"i\" and $q_j$ the charge on atom \"j\". The other variables (e.g., $\\epsilon$, $\\sigma$, $r_0$, etc.) are parameters used adjust the force field to match a given potential energy landscape.\n",
     "\n",
@@ -435,7 +435,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/Introduction to Simulation.ipynb
+++ b/Introduction to Simulation.ipynb
@@ -218,7 +218,7 @@
     "\n",
     "#### We can  make aphysical changes to the systems and/or independently vary parameters that may be coupled in experiment.  \n",
     ">* E.g., we can arbitrary change the direction or strength of a dipole moment without having to synthesize a new system; we only need to change the model parameters. \n",
-    "> * This control allows us to excplicitely test mechanisms/hypotheses. \n",
+    "> * This control allows us to explicitly test mechanisms/hypotheses. \n",
     "\n",
     "####  Allows us to investigate the behavior of hazardous materials safely and expensive materials cheaply.\n",
     "> * Some of the earliest simulation studies looked at the impact of radiation.\n",
@@ -277,7 +277,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/Neighborlists and Dangerous Builds.ipynb
+++ b/Neighborlists and Dangerous Builds.ipynb
@@ -11,8 +11,9 @@
     "Recall that we typically apply a cutoff to pair potentials once the numerical value of the pair potential becomes very small. E.g., in our prior example of the Lennard-Jones potential:\n",
     "\n",
     "\n",
-    "$U(r) = 4\\epsilon\\left[ \\left(\\frac{\\sigma}{r}\\right)^{12}- \\left(\\frac{\\sigma}{r}\\right)^6 \\right],  r < r_c$\n",
-    "$U(r) = 0 r,  \\ge r_c$\n",
+    "$U(r) = 4\\epsilon\\left[ \\left(\\frac{\\sigma}{r}\\right)^{12}- \\left(\\frac{\\sigma}{r}\\right)^6 \\right ], \\quad r < r_c$ \n",
+    "\n",
+    "$U(r) = 0, \\quad r  \\ge r_c$\n",
     "\n",
     "Where $r_c$ is often $2.5\\sigma$. \n",
     "\n",
@@ -243,7 +244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/Neighborlists and Dangerous Builds.ipynb
+++ b/Neighborlists and Dangerous Builds.ipynb
@@ -11,9 +11,9 @@
     "Recall that we typically apply a cutoff to pair potentials once the numerical value of the pair potential becomes very small. E.g., in our prior example of the Lennard-Jones potential:\n",
     "\n",
     "\n",
-    "$U(r) = 4\\epsilon\\left[ \\left(\\frac{\\sigma}{r}\\right)^{12}- \\left(\\frac{\\sigma}{r}\\right)^6 \\right ], \\quad r < r_c$ \n",
+    "$U(r) = 4\\epsilon\\left[ \\left(\\frac{\\sigma}{r}\\right)^{12}- \\left(\\frac{\\sigma}{r}\\right)^6 \\right ], \\quad where \\quad r < r_c$ \n",
     "\n",
-    "$U(r) = 0, \\quad r  \\ge r_c$\n",
+    "$U(r) = 0, \\quad where \\quad r  \\ge r_c$\n",
     "\n",
     "Where $r_c$ is often $2.5\\sigma$. \n",
     "\n",
@@ -24,9 +24,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "number of energy calculations with no cutoff:  500500\n",
+      "number of energy calculations with with cutoff:  33879\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy\n",
     "import random\n",

--- a/Timestep Optimization.ipynb
+++ b/Timestep Optimization.ipynb
@@ -492,7 +492,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import mdtraj as md"
+    "import mdtraj as md\n",
+    "from matplotlib import pyplot"
    ]
   },
   {
@@ -604,7 +605,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changes:
- The OPLS-AA dihedrals angle 2, 3, and 4 scalers before the angles were outside the ()'s.  They are moved in now.  ( Ex: were cos(phi - phi_0)) --> now cos(2 phi - phi_0) ]
- Fixed typo in the word explicitly
- fixed potential equations and boundaries in Neighborlists and Dangerous Builds in the 1st section
- Added "from matplotlib import pyplot" for the Timestep Optimization file so it can plot properly.


If someone can let me know where these files are regularly kept, this main file is kept, I will change it there too.  I did not see it offhand.
- Introduction to Molecular Dynamics.ipynb 
-  Introduction to Simulation.ipynb 
-  Neighborlists and Dangerous Builds.ipynb 
- Timestep Optimization.ipynb